### PR TITLE
Fix bug where address#as_json would raise an exception

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -92,7 +92,7 @@ class Address < ApplicationRecord
     for_user = options.delete(:for_user)
     res = super(options)
     res[:address] = oneline
-    res[:label] = self.label.value if self.label
+    res[:label] = self.label
     res
   end
 


### PR DESCRIPTION
The bug was:

>> Address.first.as_json
Traceback (most recent call last):
        2: from (irb):8
                1: from (irb):9:in `rescue in irb_binding'
                NoMethodError (undefined method `value' for
                "Work":String)